### PR TITLE
GitHub CI: fix production of testing flatpak builds

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -44,62 +44,49 @@ jobs:
   Flatpak-test-build:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    container:
+      image: docker.io/bilelmoussaoui/flatpak-github-actions:kde-6.2
+      options: --privileged
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install flatpak flatpak-builder
-    - name: Install Flatpak KDE SDK
-      run: |
-        sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install --system -y flathub org.kde.Platform//6.2
-        sudo flatpak install --system -y flathub org.kde.Sdk//6.2
-    - name: Build the Flatpak package
-      run: |
-        pushd dist/flatpak
-        sudo flatpak-builder --repo=flatpak-repo --force-clean flatpak-build org.fedoraproject.MediaWriter.json
-        flatpak build-bundle flatpak-repo org.fedoraproject.MediaWriter.flatpak org.fedoraproject.MediaWriter
-        popd
-    - name: Upload artifacts to GitHub
-      if: github.event_name == 'push'
-      uses: actions/upload-artifact@v2
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
-        name: org.fedoraproject.MediaWriter.flatpak
-        path: dist/flatpak/org.fedoraproject.MediaWriter.flatpak
+        bundle: "org.fedoraproject.MediaWriter.flatpak"
+        manifest-path: "dist/flatpak/org.fedoraproject.MediaWriter.json"
+        cache-key: flatpak-builder-${{ github.sha }}
 
-  Flatpak:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install flatpak flatpak-builder
-    - name: Install Flatpak KDE SDK
-      run: |
-        sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install --system -y flathub org.kde.Platform//5.15
-        sudo flatpak install --system -y flathub org.kde.Sdk//5.15
-    - name: Build the Flatpak package
-      run: |
-        TAG_NAME=$(bash ./dist/get-tag-name.sh)
-        pushd dist/flatpak
-        sudo flatpak-builder --repo=flatpak-repo --force-clean flatpak-build org.fedoraproject.MediaWriter.json
-        flatpak build-bundle flatpak-repo org.fedoraproject.MediaWriter.flatpak org.fedoraproject.MediaWriter
-        mv org.fedoraproject.MediaWriter.flatpak ../../org.fedoraproject.MediaWriter-$TAG_NAME.flatpak
-        popd
-    - name: Upload to GitHub
-      if: github.event_name == 'release'
-      shell: bash
-      run: |
-        TAG_NAME=$(bash ./dist/get-tag-name.sh)
-        bash ./dist/upload-to-github.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="org.fedoraproject.MediaWriter-$TAG_NAME.flatpak"
+  #Flatpak:
+    #if: github.event_name == 'release'
+    #runs-on: ubuntu-latest
+    #steps:
+    #- uses: actions/checkout@v1
+      #with:
+        #fetch-depth: 1
+    #- name: Install dependencies
+      #run: |
+        #sudo apt update
+        #sudo apt install flatpak flatpak-builder
+    #- name: Install Flatpak KDE SDK
+      #run: |
+        #sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        #sudo flatpak install --system -y flathub org.kde.Platform//5.15
+        #sudo flatpak install --system -y flathub org.kde.Sdk//5.15
+    #- name: Build the Flatpak package
+      #run: |
+        #TAG_NAME=$(bash ./dist/get-tag-name.sh)
+        #pushd dist/flatpak
+        #sudo flatpak-builder --repo=flatpak-repo --force-clean flatpak-build org.fedoraproject.MediaWriter.json
+        #flatpak build-bundle flatpak-repo org.fedoraproject.MediaWriter.flatpak org.fedoraproject.MediaWriter
+        #mv org.fedoraproject.MediaWriter.flatpak ../../org.fedoraproject.MediaWriter-$TAG_NAME.flatpak
+        #popd
+    #- name: Upload to GitHub
+      #if: github.event_name == 'release'
+      #shell: bash
+      #run: |
+        #TAG_NAME=$(bash ./dist/get-tag-name.sh)
+        #bash ./dist/upload-to-github.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="org.fedoraproject.MediaWriter-$TAG_NAME.flatpak"
 
   #macOS:
     #runs-on: macos-latest

--- a/dist/flatpak/fmw-paths.patch
+++ b/dist/flatpak/fmw-paths.patch
@@ -1,0 +1,14 @@
+diff --git a/src/theme/CMakeLists.txt b/src/theme/CMakeLists.txt
+index de208fd..7291536 100644
+--- a/src/theme/CMakeLists.txt
++++ b/src/theme/CMakeLists.txt
+@@ -23,6 +23,6 @@ target_link_libraries(adwaitathemeplugin
+     ${ADWAITAQT_LIBRARIES}
+ )
+ 
+-install(TARGETS adwaitathemeplugin DESTINATION ${QT6_INSTALL_QML}/org/fedoraproject/AdwaitaTheme)
+-install(FILES qmldir DESTINATION ${QT6_INSTALL_QML}/org/fedoraproject/AdwaitaTheme)
+-install(DIRECTORY qml/ DESTINATION ${QT6_INSTALL_QML}/QtQuick/Controls/org/fedoraproject/AdwaitaTheme)
++install(TARGETS adwaitathemeplugin DESTINATION /app/lib/qt6/qml/org/fedoraproject/AdwaitaTheme)
++install(FILES qmldir DESTINATION /app/lib/qt6/qml/org/fedoraproject/AdwaitaTheme)
++install(DIRECTORY qml/ DESTINATION /app/lib/qt6/qml/QtQuick/Controls/org/fedoraproject/AdwaitaTheme)

--- a/dist/flatpak/org.fedoraproject.MediaWriter.json
+++ b/dist/flatpak/org.fedoraproject.MediaWriter.json
@@ -42,10 +42,13 @@
                     "branch": "qt6"
                 },
                 {
+                    "type": "patch",
+                    "path": "fmw-paths.patch"
+                },
+                {
                     "type": "shell",
                     "commands": [
-                        "rm -rf app/data/icons/hicolor/1024x1024",
-                        "sed -i 's@\${QT6_INSTALL_QML}@/app/lib/qt6/qml@' src/theme/CMakeLists.txt"
+                        "rm -rf app/data/icons/hicolor/1024x1024"
                     ]
                  }
             ]


### PR DESCRIPTION
Use flatpak-github-actions to do so instead of relying on Flatpak from Ubuntu packages. This is more reliable and it does produce
GitHub artifacts automatically.